### PR TITLE
Make polygons occlusion aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/*.txt
 dist/index.html
 
 .DS_Store
+__pycache__
 
 # Logs
 logs


### PR DESCRIPTION
# Description

Previously, when objects were placed in front of other objects both of their annotations were outputted. Now we make sure that only the visible pixels of the object are annotated:

https://user-images.githubusercontent.com/870796/228978949-16857441-ac42-48fe-ac95-021ff3fd12b9.mov

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally

## Any specific deployment considerations

No

## Docs

-  Not needed
