### PR TITLE
Add support for bbox dropzones

### DIFF
--- a/image-processing/Dockerfile
+++ b/image-processing/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /app
 
 ENV PORT 8080
 
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
+CMD exec gunicorn --bind :$PORT --workers 2 --threads 8 --timeout 3600 app:app

--- a/image-processing/deploy.sh
+++ b/image-processing/deploy.sh
@@ -1,2 +1,2 @@
 gcloud builds submit --tag gcr.io/rf-magicscissors/magicscissors-python --project rf-magicscissors
-gcloud run deploy magicscissors-python --image gcr.io/rf-magicscissors/magicscissors-python --platform managed --region us-central1 --allow-unauthenticated --project rf-magicscissors --memory 16G --cpu 4 --timeout 60m
+gcloud run deploy magicscissors-python --image gcr.io/rf-magicscissors/magicscissors-python --platform managed --region us-central1 --allow-unauthenticated --project rf-magicscissors --memory 16G --cpu 8 --timeout 60m --concurrency 1 --execution-environment gen2

--- a/image-processing/src/MagicScissorsApp.py
+++ b/image-processing/src/MagicScissorsApp.py
@@ -245,6 +245,21 @@ class MagicScissorsApp:
 
             classname = categories[annotation["category_id"]]["name"]
             segmentation = annotation["segmentation"]
+            if(len(segmentation) == 0):
+                # convert bbox to polygon ([x,y,w,h] -> [[x,y,x+w,y,x+w,y+h,x,y+h]])
+                bbox = annotation["bbox"]
+                segmentation = [[
+                    bbox[0],
+                    bbox[1],
+                    bbox[0] + bbox[2],
+                    bbox[1],
+                    bbox[0] + bbox[2],
+                    bbox[1] + bbox[3],
+                    bbox[0],
+                    bbox[1] + bbox[3],
+                ]]
+
+
             polygon = np.array(segmentation).astype(np.int32).reshape(-1, 2)
 
             obj = Background(filename, polygon, classname, split)
@@ -348,12 +363,15 @@ class MagicScissorsApp:
 if __name__ == "__main__":
     request_data = {
         "apiKey": roboflow.load_roboflow_api_key(),
-        "objectsOfInterest": "magic-scissors/grocery-items-hrmxb/8",
-        "backgrounds": "magic-scissors/shopping-carts/3",
-        "destination": "magic-scissors/synthetic-images",
+        # "objectsOfInterest": "magic-scissors/grocery-items-hrmxb/8",
+        # "backgrounds": "magic-scissors/shopping-carts/3",
+        # "destination": "magic-scissors/synthetic-images",
+        "objectsOfInterest": "cv-roasts/source-images/2",
+        "backgrounds": "cv-roasts/backgrounds-yoqbe/2",
+        "destination": "cv-roasts/coffee-cups-roboflow-livestream",
         "settings": {
             "datasetSize": 10,
-            "objectsPerImage": {"min": 5, "max": 10},
+            "objectsPerImage": {"min": 1, "max": 1},
             "sizeVariance": {"min": 0.4, "max": 0.5},
             # "annotateOcclusion": False
         }

--- a/image-processing/src/MagicScissorsApp.py
+++ b/image-processing/src/MagicScissorsApp.py
@@ -46,7 +46,7 @@ class GeneratedImage:
             obj_image = cv2.imread(obj.filename)
 
             polygon = obj.polygon
-            # print("pasting object", obj.filename)
+            print("pasting object", obj.filename)
             scale = random.uniform(scale_min, scale_max)
 
             max_y = background_image.shape[0] - (obj_image.shape[0] * scale)
@@ -311,13 +311,14 @@ class MagicScissorsApp:
             os.mkdir(folder)
 
         workspace, project = self.destination_dataset_url.split("/")
-        destination_project = v = self._rf.workspace(workspace).project(project)
+        destination_project = self._rf.workspace(workspace).project(project)
 
         batch_name = "magic_scissors_" + datetime.datetime.now().strftime(
             "%Y-%m-%d_%H-%M"
         )
 
         # for i in range(0, 1):
+        print("generating", self.dataset_size, "images")
         for i in range(0, self.dataset_size):
             num_objects = random.randint(
                 self.min_objects_per_image, self.max_objects_per_image

--- a/image-processing/src/app.py
+++ b/image-processing/src/app.py
@@ -9,6 +9,9 @@ from MagicScissorsApp import MagicScissorsApp
 
 app = Flask(__name__)
 
+@app.route('/')
+def index():
+    return "Ok."
 
 @app.route("/python/go", methods=["POST"])
 def go():


### PR DESCRIPTION
# Description

Encountered a crash during [this livestream](https://www.youtube.com/watch?v=gtRfx-q5AFc) and it turns out the problem was that we expected the dropzones on the backgrounds to be polygonal. If they were bounding boxes it was crashing. This PR converts the bboxes to polygons we can use.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally

## Any specific deployment considerations

No

## Docs

- Not needed
